### PR TITLE
Updated template for CMD entry point

### DIFF
--- a/condax/core.py
+++ b/condax/core.py
@@ -15,7 +15,8 @@ def create_link(exe):
         win_path = pathlib.PureWindowsPath(exe)
         name_only, _ = os.path.splitext(executable_name)
         with open(f"{CONDAX_LINK_DESTINATION}/{name_only}.bat", "w") as fo:
-            fo.writelines(["REM Entrypoint created by condax", f'CALL "{win_path}" %*'])
+            fo.writelines(["@echo off\n", "REM Entrypoint created by condax\n",
+                           f'CALL "{win_path}" %*'])
     else:
         print(os.listdir(CONDAX_LINK_DESTINATION))
         os.symlink(exe, f"{CONDAX_LINK_DESTINATION}/{executable_name}")


### PR DESCRIPTION
Previously, the Windows CMD entry point created by condax was missing a new line character. This produced a completely commented out command:
```batch
REM Entrypoint created by condax CALL "C:\Users\Charles\.condax\flake8\Scripts\flake8.exe" %*
```

This pull request adds the newline character, and an additional `@echo off` - so the `REM` and `CALL` lines are not echoed to the console prior to running the executable.