### PR TITLE
Allow installing specific version

### DIFF
--- a/condax/conda.py
+++ b/condax/conda.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -112,14 +113,23 @@ def conda_env_prefix(package):
     return os.path.join(CONDA_ENV_PREFIX_PATH, package)
 
 
+_RE_PKG_NAME = re.compile(r"^[a-zA-Z0-9._-]+")
+
+
+def package_name(package_spec):
+    """Get the package name from a package spec"""
+    return _RE_PKG_NAME.match(package_spec).group(0)
+
+
 def detemine_executables_from_env(package):
     env_prefix = conda_env_prefix(package)
 
-    glob_pattern = os.path.join(env_prefix, "conda-meta", f"{package}*.json")
+    name = package_name(package)
+    glob_pattern = os.path.join(env_prefix, "conda-meta", f"{name}*.json")
     for file_name in glob.glob(glob_pattern):
         with open(file_name, "r") as fo:
             package_info = json.load(fo)
-            if package_info["name"] == package:
+            if package_info["name"] == name:
                 potential_executables = [
                     fn
                     for fn in package_info["files"]

--- a/news/specific-version.md
+++ b/news/specific-version.md
@@ -1,0 +1,3 @@
+### Added:
+
+* Allow installation of specific version of a package (e.g. `condax install python=3.8`)


### PR DESCRIPTION
Fixes #42

Users can install packages with specific versions like this:

    condax install mypackage=1.2.3

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
