### PR TITLE
Rework CLI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
         cache-dependency-path: |
           pyproject.toml
           ci/requirements.txt

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache-dependency-path: |
           pyproject.toml
-          ci_deps.txt
+          ci/requirements.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 6
       matrix:
@@ -24,11 +24,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build
+        python -m pip install --upgrade --quiet pip build
 
     - name: Lint with flake8
       run: |
-        pip install flake8
+        pip install  --quiet flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pip install pytest
+        pip install --quiet pytest
         pip install -e .
         pytest .
         

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip install --quiet pytest
         pip install -e .
-        pytest .
+        pytest --showlocals .
         
     - name: Attempt to install library
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache-dependency-path: 'pyproject.toml'
+        cache-dependency-path: |
+          pyproject.toml
+          ci_deps.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Run the installed package
       run: |
-        export PATH="$PATH:${HOME}/.local/bin"
+        $env:Path = "$PATH;${HOME}/.local/bin"
         black --help
       if: matrix.os == 'windows-latest'
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,21 +28,22 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade --quiet pip build
+        python -m pip install --upgrade --quiet pip build flake8 pytest
 
     - name: Lint with flake8
       run: |
-        pip install  --quiet flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Install local editable
+      run: |
+        pip install -e .
+
     - name: Test with pytest
       run: |
-        pip install --quiet pytest
-        pip install -e .
-        pytest --showlocals .
+        pytest --showlocals -vrsx .
         
     - name: Attempt to install library
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,14 @@
+minimum_pre_commit_version: '2.9.0'
 repos:
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.10.1
+- repo: https://github.com/Zac-HD/shed
+  rev: 0.10.5
   hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-
-- repo: https://github.com/psf/black
-  rev: 22.6.0
-  hooks:
-  - id: black
-    language_version: python3
+    - id: shed
+      # args: [--refactor, --py39-plus]
+      types_or: [python, markdown, rst]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.971
+  rev: v0.982
   hooks:
   - id: mypy
     additional_dependencies: [types-requests, types-PyYAML]

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,4 @@
+pip
+build
+pytest
+flake8

--- a/ci_deps.txt
+++ b/ci_deps.txt
@@ -1,0 +1,4 @@
+pip
+build
+pytest
+flake8

--- a/ci_deps.txt
+++ b/ci_deps.txt
@@ -1,4 +1,0 @@
-pip
-build
-pytest
-flake8

--- a/condax/__init__.py
+++ b/condax/__init__.py
@@ -5,4 +5,7 @@ if sys.version_info < (3, 8):
 else:
     from importlib.metadata import version
 
-__version__ = version(__package__)
+try:
+    __version__ = version(__package__)
+except Exception:
+    __version__ = "unknown"

--- a/condax/cli.py
+++ b/condax/cli.py
@@ -5,7 +5,7 @@ import typer
 
 from . import config, core, paths
 
-app = typer.Typer(
+cli = typer.Typer(
     name="condax",
     help="Install and execute applications packaged by conda.",
     no_args_is_help=True,
@@ -29,7 +29,7 @@ _OPTION_LINK_ACTION = typer.Option(
 )
 
 
-@app.command(
+@cli.command(
     help=f"""\
         Install a package with condax.
 
@@ -61,7 +61,7 @@ def install(
     )
 
 
-@app.command(
+@cli.command(
     help=f"""\
         Inject a package into a condax managed environment.
 
@@ -98,7 +98,7 @@ def inject(
     )
 
 
-@app.command(
+@cli.command(
     help="""
     Remove a package installed by condax.
 
@@ -115,7 +115,7 @@ def remove(
     core.remove_package(package)
 
 
-@app.command(
+@cli.command(
     help="""
     Ensure the condax links directory is on $PATH.
 
@@ -125,12 +125,12 @@ def ensure_path() -> None:
     paths.add_path_to_environment(config.CONFIG.link_destination)
 
 
-@app.command(help="""Display the conda prefix for a condax package.""")
+@cli.command(help="""Display the conda prefix for a condax package.""")
 def prefix(package: str) -> None:
     typer.echo(core.prefix(package))
 
 
-@app.command(
+@cli.command(
     help="""
     Update package(s) installed by condax.
 
@@ -159,4 +159,4 @@ def update(
 
 
 if __name__ == "__main__":
-    app()
+    cli()

--- a/condax/cli.py
+++ b/condax/cli.py
@@ -1,53 +1,104 @@
 import sys
+from typing import List, Optional
 
-import click
+import typer
 
 from . import config, core, paths
 
-
-@click.group(help="Install and execute applications packaged by conda.")
-def cli():
-    pass
-
-
-@cli.command(
-    help=f"""
-    Install a package with condax.
-
-    This will install a package into a new conda environment and link the executable
-    provided by it to `{config.CONDAX_LINK_DESTINATION}`.
-    """
+app = typer.Typer(
+    name="condax",
+    help="Install and execute applications packaged by conda.",
+    no_args_is_help=True,
 )
-@click.option(
-    "--channel",
-    "-c",
-    multiple=True,
-    help=f"""Use the channels specified to install.  If not specified condax will
-    default to using {config.DEFAULT_CHANNELS}.""",
+
+_OPTION_MAMBA = typer.Option(
+    False,
+    "--mamba",
+    help="Force using mamba.",
 )
-@click.option(
+_OPTION_LINK_ACTION = typer.Option(
+    core.LinkConflictAction.ERROR,
     "--link-conflict",
     "-l",
-    default="error",
-    type=click.Choice([action.value for action in core.LinkConflictAction]),
-    help=f"""How to handle conflicts when a link with the same name already exists in
-    `{config.CONDAX_LINK_DESTINATION}`.  If `error` is specified, condax will exit with
-    an error if the link already exists.  If `overwrite` is specified, condax will
-    overwrite the existing link.  If `skip` is specified, condax will skip linking the
-    conflicting executable.""",
+    help=f"""\
+            How to handle conflicts when a link with the same name already exists in
+            `{config.CONFIG.link_destination}`.  If `error` is specified, condax will exit with
+            an error if the link already exists.  If `overwrite` is specified, condax will
+            overwrite the existing link.  If `skip` is specified, condax will skip linking the
+            conflicting executable.""",
 )
-@click.argument("package")
-def install(channel, package, link_conflict):
+
+
+@app.command(
+    help=f"""\
+        Install a package with condax.
+
+        This will install a package into a new conda environment and link the executable
+        provided by it to `{config.CONFIG.link_destination}`.
+        """,
+)
+def install(
+    channel: Optional[List[str]] = typer.Option(
+        None,
+        "--channel",
+        "-c",
+        help=f"""\
+            Use the channels specified to install.  If not specified condax will
+            default to using {config.CONFIG.channels}.""",
+    ),
+    link_conflict: core.LinkConflictAction = _OPTION_LINK_ACTION,
+    mamba: bool = _OPTION_MAMBA,
+    package: str = typer.Argument(...),
+):
     if channel is None or (len(channel) == 0):
-        channel = config.DEFAULT_CHANNELS
+        channel = config.CONFIG.channels
+    config.CONFIG.ensure_conda_executable(require_mamba=mamba)
+
     core.install_package(
         package,
         channels=channel,
-        link_conflict_action=core.LinkConflictAction(link_conflict),
+        link_conflict_action=link_conflict,
     )
 
 
-@cli.command(
+@app.command(
+    help=f"""\
+        Inject a package into a condax managed environment.
+
+        This will install a package into an existing condax environment.
+        """,
+)
+def inject(
+    channel: Optional[List[str]] = typer.Option(
+        None,
+        "--channel",
+        "-c",
+        help=f"""\
+            Use the channels specified to install.  If not specified condax will
+            default to using {config.CONFIG.channels}.""",
+    ),
+    mamba: bool = _OPTION_MAMBA,
+    link_conflict: core.LinkConflictAction = _OPTION_LINK_ACTION,
+    include_apps: bool = typer.Option(
+        False, "--include-apps", "Adds applications of injected package to PATH."
+    ),
+    package: str = typer.Argument(..., help="The condax environment inject into."),
+    extra_packages: List[str] = typer.Argument(..., help="Extra packages to install."),
+):
+    if channel is None or (len(channel) == 0):
+        channel = config.CONFIG.channels
+    config.CONFIG.ensure_conda_executable(require_mamba=mamba)
+
+    core.inject_packages(
+        package,
+        extra_packages,
+        channels=channel,
+        link_conflict_action=link_conflict,
+        include_apps=include_apps,
+    )
+
+
+@app.command(
     help="""
     Remove a package installed by condax.
 
@@ -55,52 +106,57 @@ def install(channel, package, link_conflict):
     conda environment.
     """
 )
-@click.argument("package")
-def remove(package):
+def remove(
+    package: str,
+    mamba: bool = _OPTION_MAMBA,
+):
+    config.CONFIG.ensure_conda_executable(require_mamba=mamba)
+
     core.remove_package(package)
 
 
-@cli.command(
+@app.command(
     help="""
     Ensure the condax links directory is on $PATH.
 
     This can update shell configuration files like `~/.bashrc`."""
 )
-def ensure_path():
-    paths.add_path_to_environment(config.CONDAX_LINK_DESTINATION)
+def ensure_path() -> None:
+    paths.add_path_to_environment(config.CONFIG.link_destination)
 
 
-@cli.command(
+@app.command(help="""Display the conda prefix for a condax package.""")
+def prefix(package: str) -> None:
+    typer.echo(core.prefix(package))
+
+
+@app.command(
     help="""
     Update package(s) installed by condax.
 
     This will update the underlying conda environments(s) to the latest release of a package.
 """
 )
-@click.option(
-    "--all", is_flag=True, help="Set to update all packages installed by condax"
-)
-@click.option(
-    "--link-conflict",
-    "-l",
-    default="error",
-    type=click.Choice([action.value for action in core.LinkConflictAction]),
-    help=f"""How to handle conflicts when a link with the same name already exists in
-    `{config.CONDAX_LINK_DESTINATION}`.  If `error` is specified, condax will exit with
-    an error if the link already exists.  If `overwrite` is specified, condax will
-    overwrite the existing link.  If `skip` is specified, condax will skip linking the
-    conflicting executable.""",
-)
-@click.argument("package", default="", required=False)
-@click.pass_context
-def update(ctx, all, link_conflict, package):
+def update(
+    all: bool = typer.Option(
+        False, "--all", help="Set to update all packages installed by condax"
+    ),
+    link_conflict: core.LinkConflictAction = _OPTION_LINK_ACTION,
+    mamba: bool = _OPTION_MAMBA,
+    package: Optional[str] = typer.Argument(None),
+):
+    config.CONFIG.ensure_conda_executable(require_mamba=mamba)
+    if all and package is not None:
+        typer.echo("Cannot specify --all and a package name")
+        sys.exit(1)
     if all:
-        core.update_all_packages(core.LinkConflictAction(link_conflict))
+        core.update_all_packages(link_conflict)
     elif package:
-        core.update_package(package, core.LinkConflictAction(link_conflict))
+        core.update_package(package, link_conflict)
     else:
-        print(ctx.get_help(), file=sys.stderr)
+        typer.echo("Must specify --all or a package name")
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    cli()
+    app()

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -134,14 +134,17 @@ def detemine_executables_from_env(
             potential_executables: List[str] = [
                 fn
                 for fn in package_info["files"]
-                if fn.startswith("bin/") or fn.startswith("sbin/")
-                # They are Windows style path
-                (
-                    is_windows()
-                    and (
-                        fn.lower().startswith("scripts\\")
-                        or fn.lower().startswith("library\\mingw-w64\\bin\\")
-                        or re.match(r"library\\.*\\bin\\", fn.lower())
+                if (
+                    fn.startswith("bin/")
+                    or fn.startswith("sbin/")
+                    # They are Windows style path
+                    or (
+                        is_windows()
+                        and (
+                            fn.lower().startswith("scripts\\")
+                            or fn.lower().startswith("library\\mingw-w64\\bin\\")
+                            or re.match(r"library\\.*\\bin\\", fn.lower())
+                        )
                     )
                 )
             ]

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -128,7 +128,7 @@ def detemine_executables_from_env(
     for path in metas:
         package_info = json.loads(path.read_text())
         if package_info["name"] == name:
-            potential_executables: list[str] = [
+            potential_executables: List[str] = [
                 fn
                 for fn in package_info["files"]
                 if fn.startswith("bin/")
@@ -141,7 +141,7 @@ def detemine_executables_from_env(
         raise ValueError("Could not determine package files")
 
     pathext = os.environ.get("PATHEXT", "").split(";")
-    executables: set[Path] = set()
+    executables: Set[Path] = set()
     for fn in potential_executables:
         abs_executable_path = env_prefix / fn
         # unix

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -130,6 +130,7 @@ def detemine_executables_from_env(
     for path in metas:
         package_info = json.loads(path.read_text())
         if package_info["name"] == name:
+            logging.debug("Candidate files: %s", package_info["files"])
             potential_executables: List[str] = [
                 fn
                 for fn in package_info["files"]

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -43,10 +43,10 @@ def create_conda_environment(
 
     subprocess.check_call(
         [
-            conda_exe,
+            str(conda_exe),
             "create",
             "--prefix",
-            prefix,
+            str(prefix),
             "--override-channels",
             *channels_args,
             "--quiet",
@@ -73,10 +73,10 @@ def install_conda_packages(
 
     subprocess.check_call(
         [
-            conda_exe,
+            str(conda_exe),
             "install",
             "--prefix",
-            prefix,
+            str(prefix),
             "--override-channels",
             *channels_args,
             "--quiet",
@@ -90,8 +90,9 @@ def remove_conda_env(package) -> None:
     conda_exe = CONFIG.conda_executable
     assert conda_exe is not None
 
+    prefix = conda_env_prefix(package)
     subprocess.check_call(
-        [conda_exe, "remove", "--prefix", conda_env_prefix(package), "--all", "--yes"]
+        [str(conda_exe), "remove", "--prefix", str(prefix), "--all", "--yes"]
     )
 
 
@@ -99,8 +100,9 @@ def update_conda_env(package) -> None:
     conda_exe = CONFIG.conda_executable
     assert conda_exe is not None
 
+    prefix = conda_env_prefix(package)
     subprocess.check_call(
-        [conda_exe, "update", "--prefix", conda_env_prefix(package), "--all", "--yes"]
+        [str(conda_exe), "update", "--prefix", str(prefix), "--all", "--yes"]
     )
 
 

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional, Set
 
-from .config import CONFIG
+from .config import CONFIG, is_windows
 
 
 def ensure_dest_prefix() -> None:
@@ -134,9 +134,16 @@ def detemine_executables_from_env(
             potential_executables: List[str] = [
                 fn
                 for fn in package_info["files"]
-                if fn.startswith("bin/")
-                or fn.startswith("sbin/")
-                or fn.lower().startswith("scripts/")
+                if fn.startswith("bin/") or fn.startswith("sbin/")
+                # They are Windows style path
+                (
+                    is_windows()
+                    and (
+                        fn.lower().startswith("scripts\\")
+                        or fn.lower().startswith("library\\mingw-w64\\bin\\")
+                        or re.match(r"library\\.*\\bin\\", fn.lower())
+                    )
+                )
             ]
             # TODO: Handle windows style paths
             break

--- a/condax/config.py
+++ b/condax/config.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator, Optional
 
@@ -8,6 +9,10 @@ from pydantic import BaseSettings, Field
 
 if TYPE_CHECKING:
     from _typeshed import StrPath
+
+
+def is_windows() -> bool:
+    return platform.system() == "Windows"
 
 
 class Config(BaseSettings):

--- a/condax/config.py
+++ b/condax/config.py
@@ -1,21 +1,72 @@
 import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator, Optional
 
 import yaml
+from ensureconda.api import ensureconda
+from pydantic import BaseSettings, Field
+
+if TYPE_CHECKING:
+    from _typeshed import StrPath
+
+
+class Config(BaseSettings):
+    prefix_path: Path = Path("~").expanduser() / ".condax"
+    link_destination: Path = Path("~").expanduser() / ".local" / "bin"
+    channels = ["conda-forge", "defaults"]
+    conda_executable: Optional[Path] = Field(
+        default=ensureconda(
+            mamba=True, micromamba=True, conda=True, conda_exe=True, no_install=True
+        )
+    )
+
+    class Config:
+        env_prefix = "CONDAX_"
+
+    def ensure_conda_executable(self, require_mamba: bool = True):
+        def candidates() -> "Generator[Optional[StrPath], None, None]":
+            yield ensureconda(
+                mamba=True,
+                micromamba=True,
+                conda=False,
+                conda_exe=False,
+                no_install=True,
+            )
+            if not require_mamba:
+                yield ensureconda(
+                    mamba=False,
+                    micromamba=False,
+                    conda=True,
+                    conda_exe=True,
+                    no_install=True,
+                )
+            yield ensureconda(
+                mamba=True,
+                micromamba=True,
+                no_install=False,
+                conda=False,
+                conda_exe=False,
+            )
+            if not require_mamba:
+                yield ensureconda(
+                    mamba=False,
+                    micromamba=False,
+                    no_install=False,
+                    conda=True,
+                    conda_exe=True,
+                )
+
+        for c in candidates():
+            if c is not None:
+                self.conda_executable = Path(c)
+                return
+        else:
+            raise RuntimeError("Could not find conda executable")
+
 
 _condaxrc_path = os.path.expanduser(os.path.join("~", ".condaxrc"))
 if os.path.exists(_condaxrc_path):
-    with open(_condaxrc_path, "r") as fo:
-        _config = yaml.safe_load(fo)
+    with open(_condaxrc_path) as fo:
+        CONFIG = Config(**yaml.safe_load(fo))
 else:
-    _config = {}
-
-_config.setdefault("prefix_path", os.path.join("~", ".condax"))
-_config.setdefault(
-    "link_destination", os.path.expanduser(os.path.join("~", ".local", "bin"))
-)
-_config.setdefault("channels", ["conda-forge", "defaults"])
-
-
-CONDA_ENV_PREFIX_PATH = os.path.expanduser(_config["prefix_path"])
-CONDAX_LINK_DESTINATION = os.path.expanduser(_config["link_destination"])
-DEFAULT_CHANNELS = _config["channels"]
+    CONFIG = Config()

--- a/condax/core.py
+++ b/condax/core.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Collection, Dict, Generator, List, Optional
+from typing import Any, Collection, Dict, Generator, List, Optional
 
 import typer
 
@@ -139,7 +139,13 @@ def prefix_metadata(env_prefix: Path) -> Generator[PrefixMetadata, None, None]:
     else:
         ret = PrefixMetadata(prefix=env_prefix)
     yield ret
-    metadata_path.write_text(ret.json(indent=2))
+
+    def encoder(obj: Any) -> "str | Any":
+        if isinstance(obj, Path):
+            return str(obj)
+        return obj
+
+    metadata_path.write_text(ret.json(indent=2, exclude_unset=True, encoder=encoder))
 
 
 def remove_links(executables_to_unlink: Collection[Path], env_prefix: Path) -> None:

--- a/condax/core.py
+++ b/condax/core.py
@@ -1,41 +1,57 @@
+import contextlib
 import os
 import pathlib
+import platform
 import subprocess
 import sys
 from enum import Enum
+from pathlib import Path
+from typing import Collection, Dict, Generator, List, Optional
+
+import typer
 
 from . import conda
-from .config import CONDA_ENV_PREFIX_PATH, CONDAX_LINK_DESTINATION, DEFAULT_CHANNELS
-from .paths import mkpath
+from .config import CONFIG
+from .metadata import PrefixMetadata
 
 
-class LinkConflictAction(Enum):
+class LinkConflictAction(str, Enum):
     ERROR = "error"
     OVERWRITE = "overwrite"
     SKIP = "skip"
 
 
-def create_link_windows(exe, link_conflict_action):
+def is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def link_path(exe: Path) -> Path:
+    if is_windows():
+        executable_name = exe.name
+        name_only, _ = os.path.splitext(executable_name)
+        return CONFIG.link_destination / f"{name_only}.bat"
+    else:
+        executable_name = exe.name
+        return CONFIG.link_destination / executable_name
+
+
+def create_link_windows(
+    exe: Path, link_conflict_action: LinkConflictAction
+) -> Optional[Path]:
     executable_name = os.path.basename(exe)
     # create a batch file to run our application
     win_path = pathlib.PureWindowsPath(exe)
-    name_only, _ = os.path.splitext(executable_name)
-    bat_path = f"{CONDAX_LINK_DESTINATION}/{name_only}.bat"
-    if os.path.exists(bat_path):
+    bat_path = link_path(exe)
+    if bat_path.exists():
         if link_conflict_action == LinkConflictAction.ERROR:
-            print(
-                f"Error: link already exists for {executable_name}, use --link-conflict to overwrite or skip",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            link_conflict_error_msg(executable_name)
         elif link_conflict_action == LinkConflictAction.SKIP:
-            print(
-                f"Skipping link for {executable_name} because it already exists",
-                file=sys.stderr,
-            )
-            return False
+            link_conflict_exists_msg(executable_name)
+            return None
         elif link_conflict_action == LinkConflictAction.OVERWRITE:
-            print(f"Overwriting existing link {bat_path}", file=sys.stderr)
+            typer.secho(
+                f"Overwriting existing link {bat_path}", err=True, fg=typer.colors.CYAN
+            )
             os.remove(bat_path)
     with open(bat_path, "w") as fo:
         fo.writelines(
@@ -45,115 +61,243 @@ def create_link_windows(exe, link_conflict_action):
                 f'CALL "{win_path}" %*',
             ]
         )
-    return True
+    return bat_path
 
 
-def create_link_unix(exe, link_conflict_action):
+def create_link_unix(
+    exe: Path, link_conflict_action: LinkConflictAction
+) -> Optional[Path]:
     executable_name = os.path.basename(exe)
-    dst = f"{CONDAX_LINK_DESTINATION}/{executable_name}"
+    dst = link_path(exe)
     if link_conflict_action == LinkConflictAction.OVERWRITE and os.path.exists(dst):
-        print(f"Overwriting existing link {dst}", file=sys.stderr)
+        typer.secho(f"Overwriting existing link {dst}", err=True, fg=typer.colors.CYAN)
         os.remove(dst)
     try:
-        os.symlink(exe, f"{CONDAX_LINK_DESTINATION}/{executable_name}")
-        return True
+        dest = CONFIG.link_destination / executable_name
+        os.symlink(exe, dest)
+        return dest
     except FileExistsError:
         if link_conflict_action == LinkConflictAction.ERROR:
-            print(
-                f"Error: link already exists for {executable_name}, use --link-conflict to overwrite or skip",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            link_conflict_error_msg(executable_name)
         elif link_conflict_action == LinkConflictAction.SKIP:
-            print(
-                f"Skipping link for {executable_name} because it already exists",
-                file=sys.stderr,
-            )
-            return False
+            link_conflict_exists_msg(executable_name)
+    return None
 
 
-def create_link(exe, link_conflict_action):
-    create_link_func = create_link_windows if sys.platform == "nt" else create_link_unix
-    return create_link_func(exe, link_conflict_action)
+def link_conflict_exists_msg(executable_name: str):
+    typer.secho(
+        f"Skipping link for {executable_name} because it already exists",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
 
 
-def create_links(executables_to_link, link_conflict_action):
-    print(os.listdir(CONDAX_LINK_DESTINATION))
-    link_succeeded = {}
+def link_conflict_error_msg(executable_name: str):
+    typer.secho(
+        f"Error: link already exists for {executable_name}, use --link-conflict to overwrite or skip",
+        err=True,
+        fg=typer.colors.RED,
+    )
+    sys.exit(1)
+
+
+def create_link(exe: Path, link_conflict_action: LinkConflictAction) -> Optional[Path]:
+    if is_windows():
+        return create_link_windows(exe, link_conflict_action)
+    else:
+        return create_link_unix(exe, link_conflict_action)
+
+
+def create_links(
+    executables_to_link: Collection[Path],
+    link_conflict_action: LinkConflictAction,
+    env_prefix: Path,
+) -> None:
+    link_succeeded: Dict[Path, Optional[Path]] = {}
     for exe in executables_to_link:
         link_succeeded[exe] = create_link(exe, link_conflict_action)
     if len(executables_to_link):
-        print("Created the following entrypoint links:", file=sys.stderr)
+        typer.secho(
+            "Created the following entrypoint links:", err=True, fg=typer.colors.CYAN
+        )
         for exe in executables_to_link:
             if link_succeeded[exe]:
                 executable_name = os.path.basename(exe)
-                print(f"    {executable_name}", file=sys.stderr)
+                typer.secho(f"    {executable_name}", err=True, fg=typer.colors.CYAN)
+
+    with prefix_metadata(env_prefix) as metadata:
+        metadata.links.update(
+            {k: v for k, v in link_succeeded.items() if v is not None}
+        )
 
 
-def remove_links(executables_to_unlink):
+@contextlib.contextmanager
+def prefix_metadata(env_prefix: Path) -> Generator[PrefixMetadata, None, None]:
+    metadata_path = env_prefix / ".condax-metadata.json"
+    if metadata_path.exists():
+        ret = PrefixMetadata.parse_file(metadata_path)
+    else:
+        ret = PrefixMetadata(prefix=env_prefix)
+    yield ret
+    metadata_path.write_text(ret.json(indent=2))
+
+
+def remove_links(executables_to_unlink: Collection[Path], env_prefix: Path) -> None:
+    removed_links: Dict[Path, Path] = {}
+
     for exe in executables_to_unlink:
-        executable_name = os.path.basename(exe)
-        link_name = f"{CONDAX_LINK_DESTINATION}/{executable_name}"
-        if os.path.islink(link_name) and (os.readlink(link_name) == exe):
-            os.unlink(link_name)
+        link = link_path(exe)
+        if is_windows():
+            os.unlink(link)
+            removed_links[exe] = link
+        else:
+            if os.path.islink(link) and (os.readlink(link) == exe):
+                os.unlink(link)
+                removed_links[exe] = link
+
     if len(executables_to_unlink):
-        print("Removed the following entrypoint links:", file=sys.stderr)
+        typer.secho(
+            "Removed the following entrypoint links:", err=True, fg=typer.colors.CYAN
+        )
         for exe in executables_to_unlink:
             executable_name = os.path.basename(exe)
-            print(f"    {executable_name}", file=sys.stderr)
+            typer.secho(f"    {executable_name}", err=True, fg=typer.colors.CYAN)
+
+    with prefix_metadata(env_prefix) as metadata:
+        for k in removed_links:
+            if k in metadata.links:
+                del metadata.links[k]
 
 
 def install_package(
-    package, channels=DEFAULT_CHANNELS, link_conflict_action=LinkConflictAction.ERROR
-):
+    package: str,
+    channels: Optional[List[str]] = None,
+    link_conflict_action=LinkConflictAction.ERROR,
+) -> None:
+    if channels is None:
+        channels = CONFIG.channels
     conda.create_conda_environment(package, channels=channels)
     executables_to_link = conda.detemine_executables_from_env(package)
-    mkpath(CONDAX_LINK_DESTINATION)
-    create_links(executables_to_link, link_conflict_action)
-    print(f"`{package}` has been installed by condax", file=sys.stderr)
+    CONFIG.link_destination.mkdir(parents=True, exist_ok=True)
+    create_links(
+        executables_to_link,
+        link_conflict_action,
+        env_prefix=conda.conda_env_prefix(package),
+    )
+    typer.secho(
+        f"`{package}` has been installed by condax", err=True, fg=typer.colors.GREEN
+    )
 
 
-def exit_if_not_installed(package):
+def inject_packages(
+    package: str,
+    extra_packages: List[str],
+    channels: Optional[List[str]] = None,
+    include_apps: bool = False,
+    link_conflict_action=LinkConflictAction.ERROR,
+) -> None:
+    if channels is None:
+        channels = CONFIG.channels
+
+    prefix = conda.conda_env_prefix(package)
+    conda.install_conda_packages(extra_packages, channels=channels, prefix=prefix)
+    if include_apps:
+        for extra_package in extra_packages:
+            executables_to_link = conda.detemine_executables_from_env(
+                extra_package, env_prefix=prefix
+            )
+            CONFIG.link_destination.mkdir(parents=True, exist_ok=True)
+            create_links(executables_to_link, link_conflict_action, env_prefix=prefix)
+    with prefix_metadata(prefix) as metadata:
+        metadata.injected_packages = list(
+            sorted(set(metadata.injected_packages) | set(extra_packages))
+        )
+        if include_apps:
+            metadata.injected_packages_with_apps = list(
+                sorted(set(metadata.injected_packages_with_apps) | set(extra_packages))
+            )
+
+    typer.secho(
+        f"`{' '.join(extra_packages)}` have been installed into {prefix} by condax",
+        err=True,
+        fg=typer.colors.GREEN,
+    )
+
+
+def exit_if_not_installed(package: str):
     prefix = conda.conda_env_prefix(package)
     if not os.path.exists(prefix):
-        print(f"`{package}` is not installed with condax", file=sys.stderr)
+        typer.secho(
+            f"`{package}` is not installed with condax", err=True, fg=typer.colors.RED
+        )
         sys.exit(0)
 
 
-def remove_package(package):
+def remove_package(package) -> None:
     exit_if_not_installed(package)
-
     executables_to_unlink = conda.detemine_executables_from_env(package)
-    remove_links(executables_to_unlink)
+    prefix = conda.conda_env_prefix(package)
+    remove_links(executables_to_unlink, env_prefix=prefix)
+    with prefix_metadata(prefix) as metadata:
+        additional_removals = metadata.links.keys()
+    remove_links(additional_removals, env_prefix=prefix)
+
     conda.remove_conda_env(package)
-    print(f"`{package}` has been removed from condax", file=sys.stderr)
+    typer.secho(
+        f"`{package}` has been removed from condax", err=True, fg=typer.colors.GREEN
+    )
 
 
-def update_all_packages(link_conflict_action=LinkConflictAction.ERROR):
-    for package in os.listdir(CONDA_ENV_PREFIX_PATH):
-        if os.path.isdir(os.path.join(CONDA_ENV_PREFIX_PATH, package)):
-            update_package(package, link_conflict_action)
+def update_all_packages(link_conflict_action=LinkConflictAction.ERROR) -> None:
+    for package in CONFIG.prefix_path.iterdir():
+        if package.is_dir():
+            update_package(package.name, link_conflict_action)
 
 
-def update_package(package, link_conflict_action=LinkConflictAction.ERROR):
+def prefix(package: str) -> Path:
     exit_if_not_installed(package)
+    return conda.conda_env_prefix(package)
+
+
+def update_package(package: str, link_conflict_action=LinkConflictAction.ERROR) -> None:
+    exit_if_not_installed(package)
+    env_prefix = conda.conda_env_prefix(package)
+    with prefix_metadata(env_prefix) as metadata:
+        executables_already_linked = set(metadata.links.keys())
+        injected = metadata.injected_packages
+        injected_with_apps = metadata.injected_packages_with_apps
     try:
-        executables_already_linked = set(conda.detemine_executables_from_env(package))
+        executables_already_linked |= set(conda.detemine_executables_from_env(package))
+
         conda.update_conda_env(package)
+        env_prefix = conda.conda_env_prefix(package)
         executables_linked_in_updated = set(
             conda.detemine_executables_from_env(package)
         )
+        for p in injected_with_apps:
+            executables_linked_in_updated |= set(
+                conda.detemine_executables_from_env(p, env_prefix=env_prefix)
+            )
 
         to_create = executables_linked_in_updated - executables_already_linked
         to_delete = executables_already_linked - executables_linked_in_updated
 
-        remove_links(to_delete)
-        create_links(to_create, link_conflict_action)
-        print(f"{package} update successfully")
+        remove_links(to_delete, env_prefix=env_prefix)
+        create_links(to_create, link_conflict_action, env_prefix=env_prefix)
+        typer.secho(f"`{package}` has been updated", err=True, fg=typer.colors.GREEN)
 
     except subprocess.CalledProcessError:
-        print(f"`{package}` could not be updated", file=sys.stderr)
-        print(f"removing and recreating instead", file=sys.stderr)
+        typer.secho(
+            f"`{package}` could not be updated", err=True, fg=typer.colors.YELLOW
+        )
+        typer.secho(
+            f"removing and recreating instead", err=True, fg=typer.colors.YELLOW
+        )
 
         remove_package(package)
         install_package(package)
+        if injected:
+            inject_packages(package, injected, include_apps=False)
+        if injected_with_apps:
+            inject_packages(package, injected_with_apps, include_apps=True)
+        typer.secho(f"`{package}` has been updated", err=True, fg=typer.colors.GREEN)

--- a/condax/core.py
+++ b/condax/core.py
@@ -1,7 +1,6 @@
 import contextlib
 import os
 import pathlib
-import platform
 import subprocess
 import sys
 from enum import Enum
@@ -11,7 +10,7 @@ from typing import Any, Collection, Dict, Generator, List, Optional
 import typer
 
 from . import conda
-from .config import CONFIG
+from .config import CONFIG, is_windows
 from .metadata import PrefixMetadata
 
 
@@ -19,10 +18,6 @@ class LinkConflictAction(str, Enum):
     ERROR = "error"
     OVERWRITE = "overwrite"
     SKIP = "skip"
-
-
-def is_windows() -> bool:
-    return platform.system() == "Windows"
 
 
 def link_path(exe: Path) -> Path:

--- a/condax/metadata.py
+++ b/condax/metadata.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class PrefixMetadata(BaseModel):
+    prefix: Path
+    links: Dict[Path, Path] = Field(
+        default_factory=dict,
+        description="Key is the local executable, value is the link path",
+    )
+    injected_packages: List[str] = Field(
+        default_factory=list,
+        description="Extra packages to injected into in the environment",
+    )
+    injected_packages_with_apps: List[str] = Field(
+        default_factory=list,
+        description="Extra packages to injected into in the environment with apps",
+    )

--- a/condax/paths.py
+++ b/condax/paths.py
@@ -1,6 +1,6 @@
 import os
-import sys
 
+import typer
 import userpath
 
 
@@ -12,18 +12,29 @@ def add_path_to_environment(path):
     path = str(path)
 
     post_install_message = (
-        "You likely need to open a new terminal or re-login for changes to your $PATH"
+        "You likely need to open a new terminal or re-login for changes to your PATH"
         "to take effect."
     )
     if userpath.in_current_path(path) or userpath.need_shell_restart(path):
         if userpath.need_shell_restart(path):
-            print(
+            typer.secho(
                 f"{path} has already been added to PATH. " f"{post_install_message}",
-                file=sys.stderr,
+                err=True,
+                fg=typer.colors.YELLOW,
+            )
+        else:
+            typer.secho(
+                f"{path} alread on PATH.",
+                err=True,
+                fg=typer.colors.YELLOW,
             )
         return
 
     userpath.append(path)
-    print(f"Success! Added {path} to the PATH environment variable.", file=sys.stderr)
-    print(file=sys.stderr)
-    print(post_install_message, file=sys.stderr)
+    typer.secho(
+        f"Success! Added {path} to the PATH environment variable.",
+        err=True,
+        fg=typer.colors.GREEN,
+    )
+    typer.secho()
+    typer.secho(post_install_message, err=True, fg=typer.colors.WHITE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
 	"requests",
 	"userpath",
 	"PyYAML",
+	"ensureconda",
+	"typer",
 	'importlib_metadata; python_version < "3.8.0"',
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 	"PyYAML",
 	"ensureconda",
 	"typer",
+	"pydantic",
 	'importlib_metadata; python_version < "3.8.0"',
 ]
 dynamic = ["version"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_level = DEBUG

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -6,9 +6,9 @@ import pytest
 
 
 @pytest.fixture
-def conf(tmppath_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
-    prefix = tmppath_factory.mktemp("prefix")
-    link = tmppath_factory.mktemp("link")
+def conf(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
+    prefix = tmp_path_factory.mktemp("prefix")
+    link = tmp_path_factory.mktemp("link")
 
     import condax.config
 

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -18,6 +18,13 @@ def conf(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPat
     return {"prefix": str(prefix), "link": str(link)}
 
 
+@pytest.fixture(scope="session", autouse=True)
+def ensure_conda_executable() -> None:
+    from condax.config import CONFIG
+
+    CONFIG.ensure_conda_executable()
+
+
 def test_pipx_install_roundtrip(conf):
     from condax.core import install_package, remove_package
 

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -6,9 +6,9 @@ import pytest
 
 
 @pytest.fixture
-def conf(tmpdir_factory, monkeypatch):
-    prefix = tmpdir_factory.mktemp("prefix")
-    link = tmpdir_factory.mktemp("link")
+def conf(tmppath_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
+    prefix = tmppath_factory.mktemp("prefix")
+    link = tmppath_factory.mktemp("link")
 
     import condax.config
 
@@ -25,6 +25,7 @@ def test_pipx_install_roundtrip(conf):
     assert (start is None) or (not start.startswith(conf["link"]))
     install_package("jq")
     post_install = which("jq")
+    assert post_install is not None
     assert post_install.startswith(conf["link"])
 
     # ensure that the executable installed is on PATH

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -31,7 +31,14 @@ def test_pipx_install_roundtrip(conf):
     start = which("jq")
     assert (start is None) or (not start.startswith(conf["link"]))
     install_package("jq")
-    post_install = which("jq")
+
+    import condax.config
+
+    files = list(condax.config.CONFIG.link_destination.iterdir())
+    print("Link Prefix:", conf["link"])
+    print("Files:", files)
+
+    post_install = which("jq", path=os.environ["PATH"])
     assert post_install is not None
     assert post_install.startswith(conf["link"])
 
@@ -40,5 +47,5 @@ def test_pipx_install_roundtrip(conf):
 
     # remove the env
     remove_package("jq")
-    post_remove = which("jq")
+    post_remove = which("jq", path=os.environ["PATH"])
     assert (post_remove is None) or (not post_remove.startswith(conf["link"]))

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -12,8 +12,8 @@ def conf(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPat
 
     import condax.config
 
-    monkeypatch.setattr(condax.config, "CONDA_ENV_PREFIX_PATH", str(prefix))
-    monkeypatch.setattr(condax.config, "CONDAX_LINK_DESTINATION", str(link))
+    monkeypatch.setattr(condax.config.CONFIG, "prefix_path", prefix)
+    monkeypatch.setattr(condax.config.CONFIG, "link_destination", link)
     monkeypatch.setenv("PATH", str(link), prepend=os.pathsep)
     return {"prefix": str(prefix), "link": str(link)}
 


### PR DESCRIPTION
* Switch the CLI to typer
* Add the `inject` command.
   - This also adds a new metadata file we write to the prefix to know which packages have been injected
* Use `ensureconde` to find conda binary, default to using `mamba`
* Add `--mamba` flag to force using `mamba`
* Fixed windows support
* Actually enable windows and osx testing
