### PR TITLE
Update windows path separator in executable search

### DIFF
--- a/condax/conda.py
+++ b/condax/conda.py
@@ -120,7 +120,7 @@ def package_name(package_spec: str):
     return m.group(0)
 
 
-def detemine_executables_from_env(
+def determine_executables_from_env(
     package: str, env_prefix: Optional[Path] = None
 ) -> Set[Path]:
     if env_prefix is None:

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -141,9 +141,9 @@ def detemine_executables_from_env(
                     or (
                         is_windows()
                         and (
-                            fn.lower().startswith("scripts\\")
-                            or fn.lower().startswith("library\\mingw-w64\\bin\\")
-                            or re.match(r"library\\.*\\bin\\", fn.lower())
+                            fn.lower().startswith("scripts/")
+                            or fn.lower().startswith("library/mingw-w64/bin/")
+                            or re.match(r"library/.*/bin/", fn.lower())
                         )
                     )
                 )

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -131,24 +131,19 @@ def detemine_executables_from_env(
         package_info = json.loads(path.read_text())
         if package_info["name"] == name:
             logging.debug("Candidate files: %s", package_info["files"])
-            potential_executables: List[str] = [
-                fn
-                for fn in package_info["files"]
-                if (
-                    fn.startswith("bin/")
-                    or fn.startswith("sbin/")
-                    # They are Windows style path
-                    or (
-                        is_windows()
-                        and (
-                            fn.lower().startswith("scripts/")
-                            or fn.lower().startswith("library/mingw-w64/bin/")
-                            or re.match(r"library/.*/bin/", fn.lower())
-                        )
-                    )
-                )
-            ]
-            # TODO: Handle windows style paths
+            potential_executables: List[str] = []
+            for fn in package_info["files"]:
+                if is_windows():
+                    processed_fn = fn.lower().replace("\\", "/")
+                    if (
+                        processed_fn.startswith("scripts/")
+                        or processed_fn.startswith("library/mingw-w64/bin/")
+                        or re.match(r"library/.*/bin/", processed_fn)
+                    ):
+                        potential_executables.append(fn)
+                else:
+                    if fn.startswith("bin/") or fn.startswith("sbin/"):
+                        potential_executables.append(fn)
             break
     else:
         raise ValueError("Could not determine package files")

--- a/condax/core.py
+++ b/condax/core.py
@@ -178,7 +178,7 @@ def install_package(
     if channels is None:
         channels = CONFIG.channels
     conda.create_conda_environment(package, channels=channels)
-    executables_to_link = conda.detemine_executables_from_env(package)
+    executables_to_link = conda.determine_executables_from_env(package)
     CONFIG.link_destination.mkdir(parents=True, exist_ok=True)
     create_links(
         executables_to_link,
@@ -204,7 +204,7 @@ def inject_packages(
     conda.install_conda_packages(extra_packages, channels=channels, prefix=prefix)
     if include_apps:
         for extra_package in extra_packages:
-            executables_to_link = conda.detemine_executables_from_env(
+            executables_to_link = conda.determine_executables_from_env(
                 extra_package, env_prefix=prefix
             )
             CONFIG.link_destination.mkdir(parents=True, exist_ok=True)
@@ -236,7 +236,7 @@ def exit_if_not_installed(package: str):
 
 def remove_package(package) -> None:
     exit_if_not_installed(package)
-    executables_to_unlink = conda.detemine_executables_from_env(package)
+    executables_to_unlink = conda.determine_executables_from_env(package)
     prefix = conda.conda_env_prefix(package)
     remove_links(executables_to_unlink, env_prefix=prefix)
     with prefix_metadata(prefix) as metadata:
@@ -268,16 +268,16 @@ def update_package(package: str, link_conflict_action=LinkConflictAction.ERROR) 
         injected = metadata.injected_packages
         injected_with_apps = metadata.injected_packages_with_apps
     try:
-        executables_already_linked |= set(conda.detemine_executables_from_env(package))
+        executables_already_linked |= set(conda.determine_executables_from_env(package))
 
         conda.update_conda_env(package)
         env_prefix = conda.conda_env_prefix(package)
         executables_linked_in_updated = set(
-            conda.detemine_executables_from_env(package)
+            conda.determine_executables_from_env(package)
         )
         for p in injected_with_apps:
             executables_linked_in_updated |= set(
-                conda.detemine_executables_from_env(p, env_prefix=env_prefix)
+                conda.determine_executables_from_env(p, env_prefix=env_prefix)
             )
 
         to_create = executables_linked_in_updated - executables_already_linked

--- a/tests/test_condax.py
+++ b/tests/test_condax.py
@@ -43,7 +43,7 @@ def test_pipx_install_roundtrip(conf):
     assert post_install.startswith(conf["link"])
 
     # ensure that the executable installed is on PATH
-    subprocess.check_call(["jq", "--help"])
+    subprocess.check_call(["jq", "--help"], shell=True)
 
     # remove the env
     remove_package("jq")


### PR DESCRIPTION
Using version `0.1.1` on windows, `condax install` appears to run successfully, however no batch file is created in `~/.local/bin`. This issue can be traced to the identification of executables using the `conda-meta` JSON data. The relative paths listed under the `files` key are (to the extend of my research) always expressed with forward slashes. This is simple fix to get `condax` working on windows in anticipation of a more robust check.
