### PR TITLE
Fix expansion of ~

### DIFF
--- a/condax/config.py
+++ b/condax/config.py
@@ -36,8 +36,8 @@ class Config(BaseSettings):
 
     @field_validator("prefix_path", "link_destination", mode="before")
     @classmethod
-    def ensure_prefix_path(cls, v: Path) -> Path:
-        v = v.expanduser()
+    def ensure_prefix_path(cls, v: os.PathLike) -> Path:
+        v = Path(v).expanduser()
         if not v.exists():
             v.mkdir(parents=True, exist_ok=True)
         v = v.resolve()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The previous fix didn't actually fix the issue, as the field validator written was expecting a `Path` when the actual input is a string when reading in from the yaml configuration.

It might be helpful to add the CI for running tests as the type checker caught this issue.