### PR TITLE
Support XDG directories

### DIFF
--- a/condax/config.py
+++ b/condax/config.py
@@ -84,9 +84,7 @@ class Config(BaseSettings):
             raise RuntimeError("Could not find conda executable")
 
 
-_condaxrc_path_list = [
-    os.path.expanduser(os.path.join("~", ".condaxrc"))
-]
+_condaxrc_path_list = [os.path.expanduser(os.path.join("~", ".condaxrc"))]
 if "CONDAXRC" in os.environ:
     _condaxrc_path_list = [os.environ["CONDAXRC"]] + _condaxrc_path_list
 if "XDG_CONFIG_HOME" in os.environ:
@@ -106,7 +104,7 @@ _condaxrc_path_list += [
     "/etc/condax/condaxrc",
     "/etc/condax/.condaxrc",
     "/var/lib/condax/condaxrc",
-    "/var/lib/condax/.condaxrc"
+    "/var/lib/condax/.condaxrc",
 ]
 _condaxrc_path_list = [x for x in _condaxrc_path_list if os.path.exists(x)]
 if any(_condaxrc_path_list):

--- a/condax/config.py
+++ b/condax/config.py
@@ -99,6 +99,10 @@ if "XDG_CONFIG_HOME" in os.environ:
         ),
     ]
 _condaxrc_path_list += [
+    os.path.join("~", ".condax", "condaxrc"),
+    os.path.join("~", ".condax", ".condaxrc"),
+    os.path.join("~", ".config", "condax", "condaxrc"),
+    os.path.join("~", ".config", "condax", ".condaxrc"),
     "/etc/condax/condaxrc",
     "/etc/condax/.condaxrc",
     "/var/lib/condax/condaxrc",

--- a/condax/config.py
+++ b/condax/config.py
@@ -84,7 +84,11 @@ class Config(BaseSettings):
             raise RuntimeError("Could not find conda executable")
 
 
-_condaxrc_path_list = [os.path.expanduser(os.path.join("~", ".condaxrc"))]
+_condaxrc_path_list = [
+    os.path.expanduser(os.path.join("~", ".condaxrc"))
+]
+if "CONDAXRC" in os.environ:
+    _condaxrc_path_list = [os.environ["CONDAXRC"]] + _condaxrc_path_list
 if "XDG_CONFIG_HOME" in os.environ:
     _condaxrc_path_list += [
         os.path.expanduser(
@@ -94,6 +98,12 @@ if "XDG_CONFIG_HOME" in os.environ:
             os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", ".condaxrc")
         ),
     ]
+_condaxrc_path_list += [
+    "/etc/condax/condaxrc",
+    "/etc/condax/.condaxrc",
+    "/var/lib/condax/condaxrc",
+    "/var/lib/condax/.condaxrc"
+]
 _condaxrc_path_list = [x for x in _condaxrc_path_list if os.path.exists(x)]
 if any(_condaxrc_path_list):
     _condaxrc_path = _condaxrc_path_list[0]

--- a/condax/config.py
+++ b/condax/config.py
@@ -83,17 +83,20 @@ class Config(BaseSettings):
         else:
             raise RuntimeError("Could not find conda executable")
 
-_condaxrc_path = [
-    os.path.expanduser(os.path.join("~", ".condaxrc"))
-]
+
+_condaxrc_path_list = [os.path.expanduser(os.path.join("~", ".condaxrc"))]
 if "XDG_CONFIG_HOME" in os.environ:
-    _condaxrc_path += [
-        os.path.expanduser(os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", "condaxrc")),
-        os.path.expanduser(os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", ".condaxrc"))
+    _condaxrc_path_list += [
+        os.path.expanduser(
+            os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", "condaxrc")
+        ),
+        os.path.expanduser(
+            os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", ".condaxrc")
+        ),
     ]
-_condaxrc_path = [x for x in _condaxrc_path if os.path.exists(x)]
-if any(_condaxrc_path):
-    _condaxrc_path = _condaxrc_path[0]
+_condaxrc_path_list = [x for x in _condaxrc_path_list if os.path.exists(x)]
+if any(_condaxrc_path_list):
+    _condaxrc_path = _condaxrc_path_list[0]
     with open(_condaxrc_path) as fo:
         CONFIG = Config(**yaml.safe_load(fo))
 else:

--- a/condax/config.py
+++ b/condax/config.py
@@ -83,9 +83,17 @@ class Config(BaseSettings):
         else:
             raise RuntimeError("Could not find conda executable")
 
-
-_condaxrc_path = os.path.expanduser(os.path.join("~", ".condaxrc"))
-if os.path.exists(_condaxrc_path):
+_condaxrc_path = [
+    os.path.expanduser(os.path.join("~", ".condaxrc"))
+]
+if "XDG_CONFIG_HOME" in os.environ:
+    _condaxrc_path += [
+        os.path.expanduser(os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", "condaxrc")),
+        os.path.expanduser(os.path.join(os.environ["XDG_CONFIG_HOME"], "condax", ".condaxrc"))
+    ]
+_condaxrc_path = [x for x in _condaxrc_path if os.path.exists(x)]
+if any(_condaxrc_path):
+    _condaxrc_path = _condaxrc_path[0]
     with open(_condaxrc_path) as fo:
         CONFIG = Config(**yaml.safe_load(fo))
 else:

--- a/news/xdg_config.md
+++ b/news/xdg_config.md
@@ -1,3 +1,3 @@
 ### Added:
 
-* Look for `condaxrc` in `$XDG_CONFIG_HOME/condax` (usually `~/.config/condax`), if `~/.condaxrc` is not present.
+* Look for `condaxrc` in `$XDG_CONFIG_HOME/condax` (usually `~/.config/condax`) and other paths, if `~/.condaxrc` is not present.

--- a/news/xdg_config.md
+++ b/news/xdg_config.md
@@ -1,0 +1,3 @@
+### Added:
+
+* Look for `condaxrc` in `$XDG_CONFIG_HOME/condax` (usually `~/.config/condax`), if `~/.condaxrc` is not present.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR make condax comply with [XDG Base Directory specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). When `~/.condaxrc` is not present, it will be searched into `$XDG_CONFIG_HOME/condax/condaxrc` and `$XDG_CONFIG_HOME/condax/.condaxrc`, following this order of priority.
This feature has already been added in conda, mamba and micromamba.

NB: the other condax directories can be made compliant to the XDG schemas by adding this line in condaxrc: `prefix_path: "~/.local/share/condax"`.

UPDATE: on second thought, I might as well add [all the directories looked by conda](https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc), including `/etc/condax` and `/var/lib/condax` for system-wide configurations.
So, this would be the priority for the search path (higher to lower):

1. `$CONDAXRC` (if variable is set)
2. `~/.condaxrc`
3. `$XDG_CONFIG_HOME/condax/condaxrc` (if variable is set)
4. `$XDG_CONFIG_HOME/condax/.condaxrc` (if variable is set)
5. `~/.condax/condaxrc`
6. `~/.condax/.condaxrc`
7. `~/.config/condax/condaxrc`
8. `~/.config/condax/.condaxrc`
9. `/etc/condax/condaxrc`
10. `/etc/condax/.condaxrc`
11. `/var/lib/condax/condaxrc`
12. `/var/lib/condax/.condaxrc`

How does it look?