### PR TITLE
Fix links not removed after uninstalling package

### DIFF
--- a/condax/core.py
+++ b/condax/core.py
@@ -147,7 +147,7 @@ def remove_links(executables_to_unlink: Collection[Path], env_prefix: Path) -> N
             os.unlink(link)
             removed_links[exe] = link
         else:
-            if os.path.islink(link) and (os.readlink(link) == exe):
+            if os.path.islink(link) and (os.readlink(link) == str(exe)):
                 os.unlink(link)
                 removed_links[exe] = link
 

--- a/news/fix_remove_links.md
+++ b/news/fix_remove_links.md
@@ -1,0 +1,23 @@
+### Added:
+
+* <news item>
+
+### Changed:
+
+* <news item>
+
+### Deprecated:
+
+* <news item>
+
+### Removed:
+
+* <news item>
+
+### Fixed:
+
+* Fix links not removed after uninstalling package
+
+### Security:
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #74 

<!--
Please add any other relevant info below:
-->

It was simply caused by a comparison between `str` and `PosixPath` objects returning always false. Casting `PosixPath` to `str` fixed the bug.