### PR TITLE
Remove leading $ in README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ wheel and is available on Linux and macOS and supports
 Python 3.5+ and PyPy.
 
 ```bash
-$ pip install condax
+pip install condax
 ```
 
 ## License


### PR DESCRIPTION
Removing the leading `$` in the bash line makes it so clicking the copy button gives you just the install command.